### PR TITLE
Fix busy days slot availability and booking logic for chefs

### DIFF
--- a/src/chef/chef.service.ts
+++ b/src/chef/chef.service.ts
@@ -283,7 +283,24 @@ export class ChefService {
         HttpStatus.NOT_FOUND,
       );
     }
-    const busyDays = chef.busyDays;
+    // Get all confirmed events for this chef
+    const confirmedEvents = await this.eventModel.find({
+      chef: userId,
+      status: EventStatus.CONFIRMED,
+    });
+    // Mark isEvent: true for slots with a confirmed event
+    const busyDays = chef.busyDays.map((busyDay) => {
+      const dateStr = new Date(busyDay.date).toISOString().split('T')[0];
+      const updatedTimeSlots = busyDay.timeSlots.map((slot) => {
+        const hasConfirmed = confirmedEvents.some(
+          (event) =>
+            new Date(event.date).toISOString().split('T')[0] === dateStr &&
+            event.time === slot.time
+        );
+        return { ...slot, isEvent: hasConfirmed ? true : slot.isEvent };
+      });
+      return { ...busyDay, timeSlots: updatedTimeSlots };
+    });
     return { busyDays, success: true };
   }
 
@@ -295,7 +312,24 @@ export class ChefService {
         HttpStatus.NOT_FOUND,
       );
     }
-    const busyDays = chef.busyDays;
+    // Get all confirmed events for this chef
+    const confirmedEvents = await this.eventModel.find({
+      chef: userId,
+      status: EventStatus.CONFIRMED,
+    });
+    // Mark isEvent: true for slots with a confirmed event
+    const busyDays = chef.busyDays.map((busyDay) => {
+      const dateStr = new Date(busyDay.date).toISOString().split('T')[0];
+      const updatedTimeSlots = busyDay.timeSlots.map((slot) => {
+        const hasConfirmed = confirmedEvents.some(
+          (event) =>
+            new Date(event.date).toISOString().split('T')[0] === dateStr &&
+            event.time === slot.time
+        );
+        return { ...slot, isEvent: hasConfirmed ? true : slot.isEvent };
+      });
+      return { ...busyDay, timeSlots: updatedTimeSlots };
+    });
     return { busyDays, success: true };
   }
 

--- a/src/event/dto/confirm-booking.dto.ts
+++ b/src/event/dto/confirm-booking.dto.ts
@@ -4,6 +4,7 @@ enum BookingStatus {
   CONFIRMED = 'confirmed',
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',
+  ACCEPTED = 'accepted',
 }
 
 export class ConfirmBookingDto {
@@ -25,4 +26,10 @@ export class CancelBookingDto {
   @IsString()
   @IsNotEmpty({ message: 'Reason is required when status is REJECTED' })
   reason?: string;
+}
+
+export class AcceptBookingDto {
+  @IsEnum(BookingStatus)
+  @IsNotEmpty()
+  status: BookingStatus.ACCEPTED;
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -20,7 +20,7 @@ import { UserRole } from '../users/interfaces/user.interface';
 import { AddIngredientsDto } from './dto/add-ingredients.dto.ts';
 import { AttendanceDto } from './dto/attendance.dto';
 import { BookingDto } from './dto/booking.dto';
-import { CancelBookingDto, ConfirmBookingDto } from './dto/confirm-booking.dto';
+import { CancelBookingDto, ConfirmBookingDto, AcceptBookingDto } from './dto/confirm-booking.dto';
 import { EventService } from './event.service';
 import { GetEventQueryType } from './interfaces/event.interface';
 
@@ -127,6 +127,28 @@ export class EventController {
     } catch (error) {
       throw new HttpException(
         error.message || 'Failed to confirm booking',
+        error.status || HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Post(':eventId/accept')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.CHEF)
+  async acceptBooking(
+    @Param('eventId') eventId: string,
+    @Body() acceptBookingDto: AcceptBookingDto,
+    @Req() req: RequestUser,
+  ) {
+    try {
+      return await this.eventService.acceptBooking(
+        req.user._id.toString(),
+        eventId,
+        acceptBookingDto,
+      );
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to accept booking',
         error.status || HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/event/interfaces/event.interface.ts
+++ b/src/event/interfaces/event.interface.ts
@@ -5,6 +5,7 @@ import { LocationType } from 'src/common/interfaces/location.interface';
 
 export enum EventStatus {
   PENDING = 'pending',
+  ACCEPTED = 'accepted',
   CONFIRMED = 'confirmed',
   REJECTED = 'rejected',
   CANCELLED = 'cancelled',


### PR DESCRIPTION
- Added backend validation to ensure bookings can only be made in available (unbooked) slots from chef’s busy days.
- Updated busy days API to dynamically mark slots as booked (isEvent: true) if a confirmed event exists for that slot.
- Prevents double-booking and ensures accurate slot availability for frontend and users.